### PR TITLE
should look for updatedDate and not created date

### DIFF
--- a/src/BitbucketPharoAPI-Tests/BitbucketPullRequestsTest.class.st
+++ b/src/BitbucketPharoAPI-Tests/BitbucketPullRequestsTest.class.st
@@ -75,9 +75,12 @@ BitbucketPullRequestsTest >> testAllSinceUntilWithParamsInRepositoryOfProject [
 	endpoint := '/projects/' , projectKey , '/repos/' , repositorySlug
 	            , '/pull-requests'.
 
-	pullRequest1 := { (#createdDate -> sinceAsTimestamp) } asDictionary.
-	pullRequest2 := { (#createdDate -> untilPlusOneDayAsTimestamp) }
-		                asDictionary.
+	pullRequest1 := {
+		                (#createdDate -> sinceAsTimestamp).
+		                (#updatedDate -> sinceAsTimestamp) } asDictionary.
+	pullRequest2 := {
+		                (#createdDate -> untilPlusOneDayAsTimestamp).
+		                (#updatedDate -> untilPlusOneDayAsTimestamp) } asDictionary.
 
 
 	response := {
@@ -100,7 +103,7 @@ BitbucketPullRequestsTest >> testAllSinceUntilWithParamsInRepositoryOfProject [
 	"Then"
 	self assert: result size equals: 1.
 	self assert: result first equals: pullRequest1.
-		params keysAndValuesDo: [ :key :value |
+	params keysAndValuesDo: [ :key :value |
 		self assert: (client request url query at: key) equals: value ]
 ]
 

--- a/src/BitbucketPharoAPI-Tests/BitbucketPullRequestsTest.class.st
+++ b/src/BitbucketPharoAPI-Tests/BitbucketPullRequestsTest.class.st
@@ -165,6 +165,60 @@ BitbucketPullRequestsTest >> testAllSinceUntilWithParamsInRepositoryOfProjectInC
 ]
 
 { #category : 'tests' }
+BitbucketPullRequestsTest >> testAllSinceUntilWithParamsInRepositoryOfProjectOutside [
+
+	| hostUrl client endpoint bitbucketApi result response projectKey repositorySlug since until updatedDateAsTimestamp bitbucketPullRequests pullRequest1 params createdDateAsTimestamp |
+	"Given"
+	hostUrl := 'https://www.url.com'.
+	client := ZnClient new.
+
+	bitbucketApi := BitbucketApi new
+		                bearerToken: 'token';
+		                host: hostUrl;
+		                client: client.
+
+	bitbucketPullRequests := BitbucketPullRequests new bitbucketApi:
+		                         bitbucketApi.
+
+	projectKey := 'OOO'.
+	repositorySlug := 'my project'.
+	since := '02-02-2025'.
+	until := '02-09-2025'.
+	params := { (#state -> 'all') } asDictionary.
+
+	createdDateAsTimestamp := '02-01-2025' asDate asDateAndTime asUnixTime * 1000.
+	updatedDateAsTimestamp := ('02-17-2025' asDate asDateAndTime + 1 day)
+		                              asUnixTime * 1000.
+
+	endpoint := '/projects/' , projectKey , '/repos/' , repositorySlug
+	            , '/pull-requests'.
+
+	pullRequest1 := {
+		                (#createdDate -> createdDateAsTimestamp).
+		                (#updatedDate -> updatedDateAsTimestamp) } asDictionary.
+
+	response := {
+		            (#values -> {
+			             pullRequest1.
+ }).
+		            (#isLastPage -> true) } asDictionary.
+
+	client stub get willReturn: (NeoJSONWriter toString: response).
+
+
+	"When"
+	result := bitbucketPullRequests
+		          allSince: since
+		          until: until
+		          withParams: params
+		          inRepository: repositorySlug
+		          ofProject: projectKey.
+
+	"Then"
+	self assert: result size equals: 0
+]
+
+{ #category : 'tests' }
 BitbucketPullRequestsTest >> testAllWithParamsInRepositoryOfProject [
 
 	| hostUrl gitlabApi result client path bitbucketPullRequests projectKey repoSlug params pullRequest |

--- a/src/BitbucketPharoAPI-Tests/BitbucketPullRequestsTest.class.st
+++ b/src/BitbucketPharoAPI-Tests/BitbucketPullRequestsTest.class.st
@@ -108,6 +108,63 @@ BitbucketPullRequestsTest >> testAllSinceUntilWithParamsInRepositoryOfProject [
 ]
 
 { #category : 'tests' }
+BitbucketPullRequestsTest >> testAllSinceUntilWithParamsInRepositoryOfProjectInCreatedButUpdatedSince [
+
+	| hostUrl client endpoint bitbucketApi result response projectKey repositorySlug since until updatedDateAsTimestamp bitbucketPullRequests pullRequest1 params createdDateAsTimestamp |
+	"Given"
+	hostUrl := 'https://www.url.com'.
+	client := ZnClient new.
+
+	bitbucketApi := BitbucketApi new
+		                bearerToken: 'token';
+		                host: hostUrl;
+		                client: client.
+
+	bitbucketPullRequests := BitbucketPullRequests new bitbucketApi:
+		                         bitbucketApi.
+
+	projectKey := 'OOO'.
+	repositorySlug := 'my project'.
+	since := '02-02-2025'.
+	until := '02-09-2025'.
+	params := { (#state -> 'all') } asDictionary.
+
+	createdDateAsTimestamp := '02-08-2025' asDate asDateAndTime asUnixTime * 1000.
+	updatedDateAsTimestamp := ('02-17-2025' asDate asDateAndTime + 1 day)
+		                              asUnixTime * 1000.
+
+	endpoint := '/projects/' , projectKey , '/repos/' , repositorySlug
+	            , '/pull-requests'.
+
+	pullRequest1 := {
+		                (#createdDate -> createdDateAsTimestamp).
+		                (#updatedDate -> updatedDateAsTimestamp) } asDictionary.
+
+	response := {
+		            (#values -> {
+			             pullRequest1.
+ }).
+		            (#isLastPage -> true) } asDictionary.
+
+	client stub get willReturn: (NeoJSONWriter toString: response).
+
+
+	"When"
+	result := bitbucketPullRequests
+		          allSince: since
+		          until: until
+		          withParams: params
+		          inRepository: repositorySlug
+		          ofProject: projectKey.
+
+	"Then"
+	self assert: result size equals: 1.
+	self assert: result first equals: pullRequest1.
+	params keysAndValuesDo: [ :key :value |
+		self assert: (client request url query at: key) equals: value ]
+]
+
+{ #category : 'tests' }
 BitbucketPullRequestsTest >> testAllWithParamsInRepositoryOfProject [
 
 	| hostUrl gitlabApi result client path bitbucketPullRequests projectKey repoSlug params pullRequest |

--- a/src/BitbucketPharoAPI/BitbucketPullRequests.class.st
+++ b/src/BitbucketPharoAPI/BitbucketPullRequests.class.st
@@ -30,6 +30,8 @@ BitbucketPullRequests >> allSince: since until: until withParams: paramsDictiona
 
 	paramsDictionary keysAndValuesDo: [ :key :value |
 		bitbucketApi client queryAt: key put: value ].
+	
+	bitbucketApi client queryAt: #order put: 'NEWEST'.
 
 	pullRequests := OrderedCollection new.
 

--- a/src/BitbucketPharoAPI/BitbucketPullRequests.class.st
+++ b/src/BitbucketPharoAPI/BitbucketPullRequests.class.st
@@ -50,14 +50,20 @@ BitbucketPullRequests >> allSince: since until: until withParams: paramsDictiona
 			lastDate := DateAndTime fromUnixTime: updatedDateTimestamp / 1000.
 			since asDate <= lastDate ] ] whileTrue.
 	^ pullRequests select: [ :pullRequest |
-		  | updatedDate |
+		  | updatedDate createdDate |
 		  "We select all PR with activities at least between the date to miss nothing"
 		  updatedDate := DateAndTime fromUnixTime:
 			                 (pullRequest at: #updatedDate) / 1000.
+		  createdDate := DateAndTime fromUnixTime:
+			                 (pullRequest at: #createdDate) / 1000.
 
-		  updatedDate
-			  between: since asDate asDateAndTime
-			  and: until asDate asDateAndTime ]
+
+		  (updatedDate
+			   between: since asDate asDateAndTime
+			   and: until asDate asDateAndTime) or: [
+			  createdDate
+				  between: since asDate asDateAndTime
+				  and: until asDate asDateAndTime ] ]
 ]
 
 { #category : 'api - get' }

--- a/src/BitbucketPharoAPI/BitbucketPullRequests.class.st
+++ b/src/BitbucketPharoAPI/BitbucketPullRequests.class.st
@@ -21,7 +21,8 @@ BitbucketPullRequests >> allSince: since until: until withParams: paramsDictiona
 	"GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests?direction&at&state&order&withAttributes&withProperties"
 
 	"There is no parameter in the API that allows us to directly get all the commits between two dates, so we have to do it manually."
-	| results lastDate endpoint pullRequests createdDateTimestamp |
+
+	| results lastDate endpoint pullRequests |
 	bitbucketApi prepareClient.
 	endpoint := '/projects/' , projectKey , '/repos/' , repositorySlug
 	            , '/pull-requests'.
@@ -44,16 +45,19 @@ BitbucketPullRequests >> allSince: since until: until withParams: paramsDictiona
 	(results at: #isLastPage)
 		ifTrue: [ false ]
 		ifFalse: [
-			createdDateTimestamp := pullRequests last at: #createdDate.
-			lastDate := DateAndTime fromUnixTime: createdDateTimestamp / 1000.
+			| updatedDateTimestamp |
+			updatedDateTimestamp := pullRequests last at: #updatedDate.
+			lastDate := DateAndTime fromUnixTime: updatedDateTimestamp / 1000.
 			since asDate <= lastDate ] ] whileTrue.
-
 	^ pullRequests select: [ :pullRequest |
-		  | createdDate |
-		  createdDate := DateAndTime fromUnixTime:
-			                 (pullRequest at: #createdDate) / 1000.
-		  createdDate >= since asDate asDateAndTime and:
-			  createdDate <= until asDate asDateAndTime ]
+		  | updatedDate |
+		  "We select all PR with activities at least between the date to miss nothing"
+		  updatedDate := DateAndTime fromUnixTime:
+			                 (pullRequest at: #updatedDate) / 1000.
+
+		  updatedDate
+			  between: since asDate asDateAndTime
+			  and: until asDate asDateAndTime ]
 ]
 
 { #category : 'api - get' }


### PR DESCRIPTION
I think when computing MR since/until, we should look for `updatedDate` and not `createdDate`

# Current bug

Currently we look for createdDate (with the paged API)
If the last entry is for example

```json
{
    "updatedDate": "18-04-2025",
    "createdDate": "20-01-2024"
}
```

We stop to look for next entries because createdDate is in **2024** and so far away, whereas, next MR can have been created 1 day before and merged directly (which is under the period expected)

# Proposal

What is interesting is all MR with activity during this period. 
There are three possible options

1. MR is created during the period
2. MR is updated during the period
3. MR is closed (or merged) during the period

In case 1.
- updatedDate will be the same

In case 3. 
- updatedDate will be merge date wich is interesting.

In case the update is between create and merge, we get the MR updated. We can retrieve the creation information thanks to the `create_at` property, and the `merge_at` will be nil.




